### PR TITLE
Fix fieldsProcessor bug with pandas>=3.0 (NaN handling)

### DIFF
--- a/randan/scrapingVK/newsFeedSearch.py
+++ b/randan/scrapingVK/newsFeedSearch.py
@@ -284,6 +284,8 @@ def fieldsProcessor(dfIn, fieldsColumn, response):
         # print('idsCopyStr':, idsCopyStr) # для отладки
     
     def fieldsIdsChecker(cellContent): # функция, приминяемая ниже посредством apply , чтобы ускорить процесс (по сравнению с циклом по ячейкам)
+        if pandas.isna(cellContent):
+            return ''
         idsCopy = cellContent.split('idsCopy')[1].split(', ')
         cellContent = cellContent.split('idsCopy')[0]
         idsToItemS = []


### PR DESCRIPTION
Fixes a bug in fieldsProcessor func when using the `fields` parameter with pandas >= 3.0.
In pandas <= 2.x astype(str) converted NaN to the string "nan"