### PR TITLE
Fix dtype int bug in utils.py/classification_table

### DIFF
--- a/randan/utils.py
+++ b/randan/utils.py
@@ -63,7 +63,7 @@ def confidence_interval_comparison(first_ci, second_ci):
 def classification_table(y_true, y_predicted):
     classification = pd.crosstab(y_true, 
                                     y_predicted,
-                                    margins=True)
+                                    margins=True).astype(float)
     classification.index.name = 'Observed'
     classification.columns.name = 'Predicted'
     all_categories = list(classification.index)


### PR DESCRIPTION
`pd.crosstab()` creates an int64 DataFrame, but later `float` values are written into the same DataFrame, which causes:
`TypeError: Invalid value ... for dtype int64` when using `randan.tree.CHAIDClassifier`

One fix is needed: `.astype(float)` 